### PR TITLE
Enable installation of PHP applications using composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This module contains the compilation logic to build:
  - Ruby Applications
  - Node Applications
+ - PHP Applications
 
 # About
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ const commonTasks = require('bitnami-gulp-common-tasks')(gulp);
 /* CI tasks */
 
 const testFiles = './test/*.js';
-const srcFiles = ['index.js', 'ruby-application/*.js', 'node-application/*.js', testFiles];
+const srcFiles = ['index.js', 'ruby-application/*.js', 'node-application/*.js', 'php-application/*.js', testFiles];
 const testArgs = {sources: srcFiles, tests: testFiles};
 
 commonTasks.test(testArgs);

--- a/index.js
+++ b/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   RubyApplication: require('./ruby-application'),
-  NodeApplication: require('./node-application')
+  NodeApplication: require('./node-application'),
+  PHPApplication: require('./php-application')
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint": "gulp lint",
     "test": "gulp test",
     "ci-test": "gulp ci-test",
-    "ci-lint": "gulp ci-lint"
+    "ci-lint": "gulp ci-lint",
+    "ci-cpd": "gulp ci-cpd"
   },
   "keywords": [
     "blacksmith"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {

--- a/php-application/index.js
+++ b/php-application/index.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const nfile = require('nami-utils').file;
+const CompilableComponent = require('blacksmith-base-components').CompilableComponent;
+
+/**
+ * Class representing a Node Application
+ * @namespace BaseComponents.NodeApplication
+ * @class
+ * @extends CompilableComponent
+ */
+class PHPApplication extends CompilableComponent {
+    build() {
+        console.log(this.prefix);
+    }
+
+    install(options) {
+    }
+}
+
+module.exports = PHPApplication;

--- a/php-application/index.js
+++ b/php-application/index.js
@@ -1,15 +1,16 @@
 'use strict';
 
 const nfile = require('nami-utils').file;
-const CompilableComponent = require('blacksmith-base-components').CompilableComponent;
+const nos = require('nami-utils').os;
+const CompiledComponent = require('blacksmith-base-components').CompiledComponent;
 
 /**
  * Class representing a PHP Application
  * @namespace BaseComponents.PHPApplication
  * @class
- * @extends CompilableComponent
+ * @extends CompiledComponent
  */
-class PHPApplication extends CompilableComponent {
+class PHPApplication extends CompiledComponent {
   /**
    * Install the PHP Application. Use composer to download and install
    * dependencies if composer.json exists.
@@ -18,8 +19,10 @@ class PHPApplication extends CompilableComponent {
   install() {
     if (nfile.exists(nfile.join(this.workingDir, 'composer.json'))) {
       const composerPath = nfile.join(this.be.prefixDir, 'php/bin/composer');
-      this.sandbox.runProgram(nfile.join(this.be.prefixDir, 'php/bin/php'), [composerPath, "install"]);
+      const opts = {cwd: this.workingDir, logger: this.logger};
+      nos.runProgram(nfile.join(this.be.prefixDir, 'php/bin/php'), [composerPath, "install"], opts);
     }
+    super.install();
   }
 }
 

--- a/php-application/index.js
+++ b/php-application/index.js
@@ -4,8 +4,8 @@ const nfile = require('nami-utils').file;
 const CompilableComponent = require('blacksmith-base-components').CompilableComponent;
 
 /**
- * Class representing a Node Application
- * @namespace BaseComponents.NodeApplication
+ * Class representing a PHP Application
+ * @namespace BaseComponents.PHPApplication
  * @class
  * @extends CompilableComponent
  */

--- a/php-application/index.js
+++ b/php-application/index.js
@@ -10,12 +10,17 @@ const CompilableComponent = require('blacksmith-base-components').CompilableComp
  * @extends CompilableComponent
  */
 class PHPApplication extends CompilableComponent {
-    build() {
-        console.log(this.prefix);
+  /**
+   * Install the PHP Application. Use composer to download and install
+   * dependencies if composer.json exists.
+   * @function BaseComponents.PHPAppliction~install
+   */
+  install() {
+    if (nfile.exists(nfile.join(this.workingDir, 'composer.json'))) {
+      const composerPath = nfile.join(this.be.prefixDir, 'php/bin/composer');
+      this.sandbox.runProgram(nfile.join(this.be.prefixDir, 'php/bin/php'), [composerPath, "install"]);
     }
-
-    install(options) {
-    }
+  }
 }
 
 module.exports = PHPApplication;

--- a/php-application/index.js
+++ b/php-application/index.js
@@ -20,7 +20,7 @@ class PHPApplication extends CompiledComponent {
     if (nfile.exists(nfile.join(this.workingDir, 'composer.json'))) {
       const composerPath = nfile.join(this.be.prefixDir, 'php/bin/composer');
       const opts = {cwd: this.workingDir, logger: this.logger};
-      nos.runProgram(nfile.join(this.be.prefixDir, 'php/bin/php'), [composerPath, "install"], opts);
+      nos.runProgram(nfile.join(this.be.prefixDir, 'php/bin/php'), [composerPath, 'install'], opts);
     }
     super.install();
   }

--- a/test/php-application.js
+++ b/test/php-application.js
@@ -2,14 +2,62 @@
 
 const PHPApplication = require('../php-application');
 const helpers = require('blacksmith-test');
+const nfile = require('nami-utils').file;
+const path = require('path');
+const chai = require('chai');
+const expect = chai.expect;
 
-describe('PHP Application', function() {
-  before('prepare environment', () => {
+describe('PHP Application', () => {
+  var be;
+  var log;
+  var phpApplication;
+  var test;
+
+  beforeEach('prepare environment', () => {
     helpers.cleanTestEnv();
+    log = {};
+    test = helpers.createTestEnv();
+    const component = helpers.createComponent(test);
+    helpers.createDummyExecutable(path.join(test.prefix, 'php/bin/php'));
+    helpers.createDummyExecutable(path.join(test.prefix, 'php/bin/composer'));
+    phpApplication = new PHPApplication({
+      id: component.id,
+      version: component.version,
+      licenses: [{
+        type: component.licenseType,
+        licenseRelativePath: component.licenseRelativePath,
+        main: true
+      }]
+    }, {logger: helpers.getDummyLogger(log)});
+    phpApplication.id = component.id;
+    phpApplication.sourceTarball = component.sourceTarball;
+    be = helpers.getDummyBuildEnvironment(test);
   });
+
   afterEach('clean environment', () => {
     helpers.cleanTestEnv();
   });
-  xit('builds a sample PHP application', () => {
+
+  context('when composer.json present', () => {
+    it('builds', () => {
+      phpApplication.setup({be});
+      phpApplication.cleanup();
+
+      // Create an empty composer.json file
+      const composerFile = path.join(test.sandbox, `${phpApplication.id}-${phpApplication.metadata.version}`, 'composer.json');
+      nfile.touch(composerFile);
+
+      phpApplication.install();
+      expect(log.text).to.contain('composer install');
+    });
+  });
+
+  context('when composer.json not present', () => {
+    it('does not build', () => {
+      phpApplication.setup({be});
+      phpApplication.cleanup();
+      phpApplication.install();
+      expect(log.text).to.not.contain('composer install');
+    });
   });
 });

--- a/test/php-application.js
+++ b/test/php-application.js
@@ -5,7 +5,9 @@ const helpers = require('blacksmith-test');
 const nfile = require('nami-utils').file;
 const path = require('path');
 const chai = require('chai');
+const chaiFs = require('chai-fs');
 const expect = chai.expect;
+chai.use(chaiFs);
 
 describe('PHP Application', () => {
   var be;
@@ -59,5 +61,24 @@ describe('PHP Application', () => {
       phpApplication.install();
       expect(log.text).to.not.contain('composer install');
     });
+  });
+
+  it('installs files to the target directory', () => {
+    phpApplication.setup({be});
+    phpApplication.cleanup();
+
+    const filename = 'sourcefile.php';
+
+    // Assert that the expected file does not exist
+    const installedFile = path.join(test.prefix, `${phpApplication.id}`, filename);
+    expect(installedFile).to.not.be.a.path();
+
+    // Create an empty file within the sandbox working directory
+    const sourceFile = path.join(test.sandbox, `${phpApplication.id}-${phpApplication.metadata.version}`, filename);
+    nfile.touch(sourceFile);
+
+    phpApplication.install();
+
+    expect(installedFile).to.be.a.path();
   });
 });

--- a/test/php-application.js
+++ b/test/php-application.js
@@ -10,10 +10,10 @@ const expect = chai.expect;
 chai.use(chaiFs);
 
 describe('PHP Application', () => {
-  var be;
-  var log;
-  var phpApplication;
-  var test;
+  let be;
+  let log;
+  let phpApplication;
+  let test;
 
   beforeEach('prepare environment', () => {
     helpers.cleanTestEnv();
@@ -46,7 +46,8 @@ describe('PHP Application', () => {
       phpApplication.cleanup();
 
       // Create an empty composer.json file
-      const composerFile = path.join(test.sandbox, `${phpApplication.id}-${phpApplication.metadata.version}`, 'composer.json');
+      const packageName = `${phpApplication.id}-${phpApplication.metadata.version}`;
+      const composerFile = path.join(test.sandbox, packageName, 'composer.json');
       nfile.touch(composerFile);
 
       phpApplication.install();

--- a/test/php-application.js
+++ b/test/php-application.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const PHPApplication = require('../php-application');
+const helpers = require('blacksmith-test');
+
+describe('PHP Application', function() {
+  before('prepare environment', () => {
+    helpers.cleanTestEnv();
+  });
+  afterEach('clean environment', () => {
+    helpers.cleanTestEnv();
+  });
+  xit('builds a sample PHP application', () => {
+  });
+});


### PR DESCRIPTION
Needed to fix T13900.

Enable installation of PHP applications using composer

If a `composer.json` file is present, then the PHP application will be
installed using `composer install`.