### PR TITLE
Add build dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
   NodeApplication: require('./node-application'),
   Node4Application: require('./node-application/node4'),
   Node7Application: require('./node-application'),
-  PHPApplication: require('./php-application')
+  PHPApplication: require('./php-application'),
+  PeclComponent: require('./pecl-component')
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@
 module.exports = {
   RubyApplication: require('./ruby-application'),
   Ruby21Application: require('./ruby-application/ruby21'),
+  Ruby23Application: require('./ruby-application'),
   NodeApplication: require('./node-application'),
   Node4Application: require('./node-application/node4'),
+  Node7Application: require('./node-application'),
   PHPApplication: require('./php-application')
 };

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 
 module.exports = {
   RubyApplication: require('./ruby-application'),
+  Ruby21Application: require('./ruby-application/ruby21'),
   NodeApplication: require('./node-application'),
+  Node4Application: require('./node-application/node4'),
   PHPApplication: require('./php-application')
 };

--- a/node-application/index.js
+++ b/node-application/index.js
@@ -18,16 +18,14 @@ class NodeApplication extends CompilableComponent {
       'libc6',
       'libmysqlclient18',
     ];
-    return [
-      {
-        'type': 'nami',
-        'id': 'node',
-        'installCommands': ['bitnami-pkg install node-7.9.0-0'],
-        'envVars': {
-          PATH: '$PATH:/opt/bitnami/node/bin:/opt/bitnami/python/bin'
-        }
-      },
-    ].concat(_.map(debianPackages, pkg => {
+    return [{
+      'type': 'nami',
+      'id': 'node',
+      'installCommands': ['bitnami-pkg install node-7.9.0-0'],
+      'envVars': {
+        PATH: '$PATH:/opt/bitnami/node/bin:/opt/bitnami/python/bin'
+      }
+    }].concat(_.map(debianPackages, pkg => {
       return {'type': 'system', 'id': pkg, distro: 'debian'};
     }));
   }

--- a/node-application/index.js
+++ b/node-application/index.js
@@ -22,7 +22,7 @@ class NodeApplication extends CompilableComponent {
       {
         'type': 'nami',
         'id': 'node',
-        'installCommands': ['bitnami-pkg install node-4.8.2-0'],
+        'installCommands': ['bitnami-pkg install node-7.9.0-0'],
         'envVars': {
           PATH: '$PATH:/opt/bitnami/node/bin:/opt/bitnami/python/bin'
         }

--- a/node-application/index.js
+++ b/node-application/index.js
@@ -11,6 +11,26 @@ const CompilableComponent = require('blacksmith/lib/base-components').Compilable
  * @extends CompilableComponent
  */
 class NodeApplication extends CompilableComponent {
+  get buildDependencies() {
+    const debianPackages = [
+      'imagemagick',
+      'ghostscript',
+      'libc6',
+      'libmysqlclient18',
+    ];
+    return [
+      {
+        'type': 'nami',
+        'id': 'node',
+        'installCommands': ['bitnami-pkg install node-4.8.2-0'],
+        'envVars': {
+          PATH: '$PATH:/opt/bitnami/node/bin:/opt/bitnami/python/bin'
+        }
+      },
+    ].concat(_.map(debianPackages, pkg => {
+      return {'type': 'system', 'id': pkg, distro: 'debian'};
+    }));
+  }
   /**
    * Create prefix and copy source files
    * @function NodeApplication~build

--- a/node-application/node4.js
+++ b/node-application/node4.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const _ = require('nami-utils/lodash-extra');
+const NodeApplication = require('./index');
+
+/**
+ * Class representing a Node Application for versions 4.X
+ * @namespace BaseComponents.Node4Application
+ * @class
+ * @extends NodeApplication
+ */
+class Node4Application extends NodeApplication {
+  get buildDependencies() {
+    const nodeApplicationBD = super.buildDependencies;
+    const node = _.find(nodeApplicationBD, {id: 'node'});
+    node.installCommands = ['bitnami-pkg install node-4.8.2-0'];
+    return nodeApplicationBD;
+  }
+}
+
+module.exports = Node4Application;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {
-    "blacksmith": "bitnami/blacksmith#v1.0.13",
+    "lodash": "^4.17.4",
     "nami-utils": "^0.2.0"
   },
   "repository": {
@@ -12,6 +12,7 @@
     "url": "https://github.com/bitnami/blacksmith-extra-component-types.git"
   },
   "devDependencies": {
+    "blacksmith": "bitnami/blacksmith#v1.0.13",
     "eslint": "^2.11.1",
     "eslint-config-bitnami": "bitnami/eslint-config-bitnami#v1.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/pecl-component/index.js
+++ b/pecl-component/index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const nfile = require('nami-utils').file;
+const MakeComponent = require('blacksmith/lib/base-components').MakeComponent;
+const PHPApplication = require('../php-application');
+
+class peclComponent extends MakeComponent {
+  get buildDependencies() {
+    return PHPApplication.prototype.buildDependencies;
+  }
+  get prefix() {
+    return nfile.join(this.be.prefixDir, 'php');
+  }
+  configureOptions() {
+    return [`--with-php-config=${this.prefix}/bin/php-config`];
+  }
+  build() {
+    this.sandbox.runProgram(nfile.join(this.prefix, 'bin/phpize'), {cwd: this.workingDir});
+    this.configure();
+  }
+  postInstall() {
+    nfile.copy(nfile.join(this.prefix, 'lib/php/extensions/no-debug-non-zts-*/*'),
+               nfile.join(this.prefix, 'lib/php/extensions/'));
+    nfile.delete(nfile.join(this.prefix, 'lib/php/extensions/no-debug-non-zts-*'));
+  }
+}
+
+module.exports = peclComponent;

--- a/php-application/index.js
+++ b/php-application/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const nfile = require('nami-utils').file;
 const nos = require('nami-utils').os;
 const CompiledComponent = require('blacksmith/lib/base-components').CompiledComponent;
@@ -11,6 +12,64 @@ const CompiledComponent = require('blacksmith/lib/base-components').CompiledComp
  * @extends CompiledComponent
  */
 class PHPApplication extends CompiledComponent {
+  get buildDependencies() {
+    const debianPackages = [
+      'libc6',
+      'zlib1g',
+      'libxslt1.1',
+      'libtidy-0.99-0',
+      'libreadline6',
+      'libncurses5',
+      'libtinfo5',
+      'libmcrypt4',
+      'libldap-2.4-2',
+      'libstdc++6',
+      'libgmp10',
+      'libpng12-0',
+      'libjpeg62-turbo',
+      'libbz2-1.0',
+      'libxml2',
+      'libssl1.0.0',
+      'libcurl3',
+      'libfreetype6',
+      'libicu52',
+      'libgcc1',
+      'libgcrypt20',
+      'libsasl2-2',
+      'libgnutls-deb0-28',
+      'liblzma5',
+      'libidn11',
+      'librtmp1',
+      'libssh2-1',
+      'libgssapi-krb5-2',
+      'libkrb5-3',
+      'libk5crypto3',
+      'libcomerr2',
+      'libgpg-error0',
+      'libp11-kit0',
+      'libtasn1-6',
+      'libnettle4',
+      'libhogweed2',
+      'libkrb5support0',
+      'libkeyutils1',
+      'libffi6',
+      'libsybdb5',
+      'libpq5'
+    ];
+    return [
+      {
+        'type': 'nami',
+        'id': 'php',
+        'installCommands': ['bitnami-pkg install php-7.0.17-0'],
+        'envVars': {
+          PATH: '$PATH:/opt/bitnami/php/bin'
+        }
+      },
+    ].concat(_.map(debianPackages, pkg => {
+      return {'type': 'system', 'id': pkg, distro: 'debian'};
+    }));
+  }
+
   /**
    * Install the PHP Application. Use composer to download and install
    * dependencies if composer.json exists.

--- a/ruby-application/index.js
+++ b/ruby-application/index.js
@@ -29,7 +29,7 @@ class RubyApplication extends CompilableComponent {
       {
         'type': 'nami',
         'id': 'ruby',
-        'installCommands': ['bitnami-pkg install ruby-2.1.10-4'],
+        'installCommands': ['bitnami-pkg install ruby-2.3.4-0'],
         'envVars': {
           PATH: '$PATH:/opt/bitnami/ruby/bin'
         }

--- a/ruby-application/index.js
+++ b/ruby-application/index.js
@@ -12,6 +12,32 @@ const CompilableComponent = require('blacksmith/lib/base-components').Compilable
  * @extends CompilableComponent
  */
 class RubyApplication extends CompilableComponent {
+  get buildDependencies() {
+    const debianPackages = [
+      'imagemagick',
+      'ghostscript',
+      'libc6',
+      'libmagickwand-dev',
+      'libmysqlclient-dev',
+      'libpq-dev',
+      'libxml2-dev',
+      'libxslt1-dev',
+      'libgmp-dev',
+      'zlib1g-dev',
+    ];
+    return [
+      {
+        'type': 'nami',
+        'id': 'ruby',
+        'installCommands': ['bitnami-pkg install ruby-2.1.10-4'],
+        'envVars': {
+          PATH: '$PATH:/opt/bitnami/ruby/bin'
+        }
+      },
+    ].concat(_.map(debianPackages, pkg => {
+      return {'type': 'system', 'id': pkg, distro: 'debian'};
+    }));
+  }
   /**
    * Create prefix and copy source files
    * @function RubyApplication~build

--- a/ruby-application/ruby21.js
+++ b/ruby-application/ruby21.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const _ = require('nami-utils/lodash-extra');
+const RubyApplication = require('./index');
+
+/**
+ * Class representing a ruby Application for versions 2.1.X
+ * @namespace BaseComponents.Ruby21Application
+ * @class
+ * @extends rubyApplication
+ */
+class Ruby21Application extends RubyApplication {
+  get buildDependencies() {
+    const rubyApplicationBD = super.buildDependencies;
+    const ruby = _.find(rubyApplicationBD, {id: 'ruby'});
+    ruby.installCommands = ['bitnami-pkg install ruby-2.1.10-4'];
+    return rubyApplicationBD;
+  }
+}
+
+module.exports = Ruby21Application;

--- a/test/node-application.js
+++ b/test/node-application.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const NodeApplication = require('../node-application');
 const path = require('path');
 const helpers = require('blacksmith/test/helpers');
@@ -15,6 +16,12 @@ describe('Node Application', function() {
   });
   afterEach('clean environment', () => {
     helpers.cleanTestEnv();
+  });
+  it('should return its buildDependencies', () => {
+    const nodeApplication = new NodeApplication();
+    expect(_.map(nodeApplication.buildDependencies, bd => bd.id)).to.be.eql([
+      'node', 'imagemagick', 'ghostscript', 'libc6', 'libmysqlclient18'
+    ]);
   });
   it('builds a sample node application', () => {
     const log = {};

--- a/test/node-application.js
+++ b/test/node-application.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const NodeApplication = require('../node-application');
+const Node4Application = require('../node-application/node4');
 const path = require('path');
 const helpers = require('blacksmith/test/helpers');
 const chai = require('chai');
@@ -60,5 +61,13 @@ describe('Node Application', function() {
       contain('npm" "install" "--production" "-no-optional"');
     expect(log.text).to.contain('npm" "install" "--production" "--test"');
     expect(log.text).to.contain('npm" "install" "test" "--save"');
+  });
+});
+
+describe('Node4 Application', function() {
+  it('should return its buildDependencies', () => {
+    const nodeApplication = new Node4Application();
+    const nodeBuildDep = _.find(nodeApplication.buildDependencies, bd => bd.id === 'node');
+    expect(nodeBuildDep.installCommands[0]).to.match(/bitnami-pkg install node-4\..*/);
   });
 });

--- a/test/pecl-component.js
+++ b/test/pecl-component.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const _ = require('lodash');
+const PHPApplication = require('../php-application');
+const PeclComponent = require('../pecl-component');
+const path = require('path');
+const helpers = require('blacksmith/test/helpers');
+const chai = require('chai');
+const chaiFs = require('chai-fs');
+const expect = chai.expect;
+chai.use(chaiFs);
+
+describe('Pecl Component', function() {
+  this.timeout(5000);
+  before('prepare environment', () => {
+    helpers.cleanTestEnv();
+  });
+  afterEach('clean environment', () => {
+    helpers.cleanTestEnv();
+  });
+  it('should return its buildDependencies', () => {
+    const peclComponent = new PeclComponent();
+    expect(peclComponent.buildDependencies).to.be.eql(PHPApplication.prototype.buildDependencies);
+  });
+  it('builds a sample pecl application', () => {
+    const log = {};
+    const test = helpers.createTestEnv();
+    const component = helpers.createComponent(test);
+    helpers.createDummyExecutable(path.join(test.prefix, 'php/bin/phpize'));
+    const peclcomponent = new PeclComponent({
+      version: component.version,
+      id: component.id,
+      licenses: [{
+        type: component.licenseType,
+        licenseRelativePath: component.licenseRelativePath,
+        main: true
+      }]
+    }, {logger: helpers.getDummyLogger(log)});
+    peclcomponent.id = component.id;
+    peclcomponent.sourceTarball = component.sourceTarball;
+    // mock make
+    peclcomponent.make = () => true;
+
+    // Build process
+    const be = helpers.getDummyBuildEnvironment(test);
+    peclcomponent.setup({be});
+    peclcomponent.cleanup();
+    peclcomponent.extract();
+    peclcomponent.copyExtraFiles();
+    peclcomponent.patch();
+    peclcomponent.postExtract();
+    peclcomponent.build();
+    peclcomponent.postBuild();
+    peclcomponent.install();
+    peclcomponent.install({extraArgs: ['--test']});
+    peclcomponent.fulfillLicenseRequirements();
+    peclcomponent.postInstall();
+    peclcomponent.minify();
+    expect(log.text).to.
+      contain(`configure" "--prefix=${test.prefix}/php" "--with-php-config=${test.prefix}/php/bin/php-config"`);
+    expect(log.text).to.contain('phpize');
+  });
+});

--- a/test/pecl-component.js
+++ b/test/pecl-component.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const PHPApplication = require('../php-application');
 const PeclComponent = require('../pecl-component');
 const path = require('path');

--- a/test/php-application.js
+++ b/test/php-application.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const PHPApplication = require('../php-application');
 const helpers = require('blacksmith/test/helpers');
 const nfile = require('nami-utils').file;
@@ -62,6 +63,17 @@ describe('PHP Application', () => {
       phpApplication.install();
       expect(log.text).to.not.contain('composer install');
     });
+  });
+
+  it('should return its buildDependencies', () => {
+    expect(_.map(phpApplication.buildDependencies, bd => bd.id)).to.be.eql([
+      'php', 'libc6', 'zlib1g', 'libxslt1.1', 'libtidy-0.99-0', 'libreadline6', 'libncurses5', 'libtinfo5',
+      'libmcrypt4', 'libldap-2.4-2', 'libstdc++6', 'libgmp10', 'libpng12-0', 'libjpeg62-turbo', 'libbz2-1.0', 'libxml2',
+      'libssl1.0.0', 'libcurl3', 'libfreetype6', 'libicu52', 'libgcc1', 'libgcrypt20', 'libsasl2-2',
+      'libgnutls-deb0-28', 'liblzma5', 'libidn11', 'librtmp1', 'libssh2-1', 'libgssapi-krb5-2', 'libkrb5-3',
+      'libk5crypto3', 'libcomerr2', 'libgpg-error0', 'libp11-kit0', 'libtasn1-6', 'libnettle4', 'libhogweed2',
+      'libkrb5support0', 'libkeyutils1', 'libffi6', 'libsybdb5', 'libpq5'
+    ]);
   });
 
   it('installs files to the target directory', () => {

--- a/test/php-application.js
+++ b/test/php-application.js
@@ -66,14 +66,15 @@ describe('PHP Application', () => {
   });
 
   it('should return its buildDependencies', () => {
-    expect(_.map(phpApplication.buildDependencies, bd => bd.id)).to.be.eql([
+    const phpRuntimeDependencies = [
       'php', 'libc6', 'zlib1g', 'libxslt1.1', 'libtidy-0.99-0', 'libreadline6', 'libncurses5', 'libtinfo5',
       'libmcrypt4', 'libldap-2.4-2', 'libstdc++6', 'libgmp10', 'libpng12-0', 'libjpeg62-turbo', 'libbz2-1.0', 'libxml2',
       'libssl1.0.0', 'libcurl3', 'libfreetype6', 'libicu52', 'libgcc1', 'libgcrypt20', 'libsasl2-2',
       'libgnutls-deb0-28', 'liblzma5', 'libidn11', 'librtmp1', 'libssh2-1', 'libgssapi-krb5-2', 'libkrb5-3',
       'libk5crypto3', 'libcomerr2', 'libgpg-error0', 'libp11-kit0', 'libtasn1-6', 'libnettle4', 'libhogweed2',
       'libkrb5support0', 'libkeyutils1', 'libffi6', 'libsybdb5', 'libpq5'
-    ]);
+    ];
+    expect(_.map(phpApplication.buildDependencies, bd => bd.id)).to.be.eql(phpRuntimeDependencies);
   });
 
   it('installs files to the target directory', () => {

--- a/test/ruby-application.js
+++ b/test/ruby-application.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const RubyApplication = require('../ruby-application');
+const Ruby21Application = require('../ruby-application/ruby21');
 const path = require('path');
 const fs = require('fs');
 const helpers = require('blacksmith/test/helpers');
@@ -20,7 +21,6 @@ describe('Ruby Application', function() {
   });
   it('should return its buildDependencies', () => {
     const rubyApplication = new RubyApplication();
-    console.log(_.map(rubyApplication.buildDependencies, bd => bd.id));
     expect(_.map(rubyApplication.buildDependencies, bd => bd.id)).to.be.eql([
       'ruby', 'imagemagick', 'ghostscript', 'libc6', 'libmagickwand-dev', 'libmysqlclient-dev', 'libpq-dev',
       'libxml2-dev', 'libxslt1-dev', 'libgmp-dev', 'zlib1g-dev'
@@ -81,5 +81,13 @@ describe('Ruby Application', function() {
     rubyApplication.postInstall();
     rubyApplication.minify();
     expect(path.join(test.prefix, component.id, 'log/passenger.3000.log')).to.not.be.a.path();
+  });
+});
+
+describe('Ruby21 Application', function() {
+  it('should return its buildDependencies', () => {
+    const rubyApplication = new Ruby21Application();
+    const rubyBuildDep = _.find(rubyApplication.buildDependencies, bd => bd.id === 'ruby');
+    expect(rubyBuildDep.installCommands[0]).to.match(/bitnami-pkg install ruby-2\.1\..*/);
   });
 });

--- a/test/ruby-application.js
+++ b/test/ruby-application.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const RubyApplication = require('../ruby-application');
 const path = require('path');
 const fs = require('fs');
@@ -16,6 +17,14 @@ describe('Ruby Application', function() {
   });
   afterEach('clean environment', () => {
     helpers.cleanTestEnv();
+  });
+  it('should return its buildDependencies', () => {
+    const rubyApplication = new RubyApplication();
+    console.log(_.map(rubyApplication.buildDependencies, bd => bd.id));
+    expect(_.map(rubyApplication.buildDependencies, bd => bd.id)).to.be.eql([
+      'ruby', 'imagemagick', 'ghostscript', 'libc6', 'libmagickwand-dev', 'libmysqlclient-dev', 'libpq-dev',
+      'libxml2-dev', 'libxslt1-dev', 'libgmp-dev', 'zlib1g-dev'
+    ]);
   });
   it('builds a sample ruby application', () => {
     const log = {};


### PR DESCRIPTION
This diff prepares the application recipes for blacksmith 2.0 in which you can define the required build dependencies.

It also includes support for PECL Components