### PR TITLE
Add support for using extra arguments when running composer install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {

--- a/php-application/index.js
+++ b/php-application/index.js
@@ -71,6 +71,14 @@ class PHPApplication extends CompiledComponent {
   }
 
   /**
+   * When running composer install, append these paramaters to the command line arguments
+   * @returns {String[]}
+   */
+  get composerInstallParameters() {
+    return [];
+  }
+
+  /**
    * Install the PHP Application. Use composer to download and install
    * dependencies if composer.json exists.
    * @function BaseComponents.PHPAppliction~install
@@ -79,7 +87,12 @@ class PHPApplication extends CompiledComponent {
     if (nfile.exists(nfile.join(this.workingDir, 'composer.json'))) {
       const composerPath = nfile.join(this.be.prefixDir, 'php/bin/composer');
       const opts = {cwd: this.workingDir, logger: this.logger};
-      nos.runProgram(nfile.join(this.be.prefixDir, 'php/bin/php'), [composerPath, 'install'], opts);
+      const phpPath = nfile.join(this.be.prefixDir, 'php/bin/php');
+      let cmdArgs = [composerPath, 'install'];
+      if (this.composerInstallParameters.length) {
+        cmdArgs = cmdArgs.concat(this.composerInstallParameters);
+      }
+      nos.runProgram(phpPath, cmdArgs, opts);
     }
     super.install();
   }

--- a/test/php-application.js
+++ b/test/php-application.js
@@ -15,7 +15,7 @@ describe('PHP Application', () => {
   let log;
   let test;
 
-  function createTestRecipe(recipeClass) {
+  function createPHPComponent(recipeClass) {
     const component = helpers.createComponent(test);
     const phpApplication = new recipeClass({
       id: component.id,
@@ -45,7 +45,7 @@ describe('PHP Application', () => {
 
   context('when composer.json present', () => {
     it('builds', () => {
-      const phpApplication = createTestRecipe(PHPApplication);
+      const phpApplication = createPHPComponent(PHPApplication);
       phpApplication.setup({be});
       phpApplication.cleanup();
 
@@ -64,7 +64,7 @@ describe('PHP Application', () => {
         }
       }
 
-      const phpApplication = createTestRecipe(CustomComposerApplication);
+      const phpApplication = createPHPComponent(CustomComposerApplication);
       phpApplication.setup({be});
       phpApplication.cleanup();
 
@@ -80,7 +80,7 @@ describe('PHP Application', () => {
 
   context('when composer.json not present', () => {
     it('does not build', () => {
-      const phpApplication = createTestRecipe(PHPApplication);
+      const phpApplication = createPHPComponent(PHPApplication);
       phpApplication.setup({be});
       phpApplication.cleanup();
       phpApplication.install();
@@ -89,7 +89,7 @@ describe('PHP Application', () => {
   });
 
   it('should return its buildDependencies', () => {
-    const phpApplication = createTestRecipe(PHPApplication);
+    const phpApplication = createPHPComponent(PHPApplication);
     const phpRuntimeDependencies = [
       'php', 'libc6', 'zlib1g', 'libxslt1.1', 'libtidy-0.99-0', 'libreadline6', 'libncurses5', 'libtinfo5',
       'libmcrypt4', 'libldap-2.4-2', 'libstdc++6', 'libgmp10', 'libpng12-0', 'libjpeg62-turbo', 'libbz2-1.0', 'libxml2',
@@ -102,7 +102,7 @@ describe('PHP Application', () => {
   });
 
   it('installs files to the target directory', () => {
-    const phpApplication = createTestRecipe(PHPApplication);
+    const phpApplication = createPHPComponent(PHPApplication);
     phpApplication.setup({be});
     phpApplication.cleanup();
 

--- a/test/php-application.js
+++ b/test/php-application.js
@@ -15,9 +15,9 @@ describe('PHP Application', () => {
   let log;
   let test;
 
-  function createPHPComponent(recipeClass) {
+  function createPHPComponent(RecipeClass) {
     const component = helpers.createComponent(test);
-    const phpApplication = new recipeClass({
+    const phpApplication = new RecipeClass({
       id: component.id,
       version: component.version,
       licenses: [{

--- a/test/php-application.js
+++ b/test/php-application.js
@@ -13,17 +13,11 @@ chai.use(chaiFs);
 describe('PHP Application', () => {
   let be;
   let log;
-  let phpApplication;
   let test;
 
-  beforeEach('prepare environment', () => {
-    helpers.cleanTestEnv();
-    log = {};
-    test = helpers.createTestEnv();
+  function createTestRecipe(recipeClass) {
     const component = helpers.createComponent(test);
-    helpers.createDummyExecutable(path.join(test.prefix, 'php/bin/php'));
-    helpers.createDummyExecutable(path.join(test.prefix, 'php/bin/composer'));
-    phpApplication = new PHPApplication({
+    const phpApplication = new recipeClass({
       id: component.id,
       version: component.version,
       licenses: [{
@@ -34,6 +28,14 @@ describe('PHP Application', () => {
     }, {logger: helpers.getDummyLogger(log)});
     phpApplication.id = component.id;
     phpApplication.sourceTarball = component.sourceTarball;
+    return phpApplication;
+  }
+  beforeEach('prepare environment', () => {
+    helpers.cleanTestEnv();
+    log = {};
+    test = helpers.createTestEnv();
+    helpers.createDummyExecutable(path.join(test.prefix, 'php/bin/php'));
+    helpers.createDummyExecutable(path.join(test.prefix, 'php/bin/composer'));
     be = helpers.getDummyBuildEnvironment(test);
   });
 
@@ -43,6 +45,7 @@ describe('PHP Application', () => {
 
   context('when composer.json present', () => {
     it('builds', () => {
+      const phpApplication = createTestRecipe(PHPApplication);
       phpApplication.setup({be});
       phpApplication.cleanup();
 
@@ -54,10 +57,30 @@ describe('PHP Application', () => {
       phpApplication.install();
       expect(log.text).to.contain('composer install');
     });
+    it('allows defining custom composer parameters', () => {
+      class CustomComposerApplication extends PHPApplication {
+        get composerInstallParameters() {
+          return super.composerInstallParameters.concat(['--no-dev']);
+        }
+      }
+
+      const phpApplication = createTestRecipe(CustomComposerApplication);
+      phpApplication.setup({be});
+      phpApplication.cleanup();
+
+      // Create an empty composer.json file
+      const packageName = `${phpApplication.id}-${phpApplication.metadata.version}`;
+      const composerFile = path.join(test.sandbox, packageName, 'composer.json');
+      nfile.touch(composerFile);
+
+      phpApplication.install();
+      expect(log.text).to.contain('composer install --no-dev');
+    });
   });
 
   context('when composer.json not present', () => {
     it('does not build', () => {
+      const phpApplication = createTestRecipe(PHPApplication);
       phpApplication.setup({be});
       phpApplication.cleanup();
       phpApplication.install();
@@ -66,6 +89,7 @@ describe('PHP Application', () => {
   });
 
   it('should return its buildDependencies', () => {
+    const phpApplication = createTestRecipe(PHPApplication);
     const phpRuntimeDependencies = [
       'php', 'libc6', 'zlib1g', 'libxslt1.1', 'libtidy-0.99-0', 'libreadline6', 'libncurses5', 'libtinfo5',
       'libmcrypt4', 'libldap-2.4-2', 'libstdc++6', 'libgmp10', 'libpng12-0', 'libjpeg62-turbo', 'libbz2-1.0', 'libxml2',
@@ -78,6 +102,7 @@ describe('PHP Application', () => {
   });
 
   it('installs files to the target directory', () => {
+    const phpApplication = createTestRecipe(PHPApplication);
     phpApplication.setup({be});
     phpApplication.cleanup();
 


### PR DESCRIPTION
PHPApplication components will run composer install if the required
file is detected. Some projects require certain additional flags for this step,
for example, skipping dev. dependencies with '--no-dev'.