### PR TITLE
Removing unnecessary step to install nokogiri on Ruby apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {

--- a/ruby-application/index.js
+++ b/ruby-application/index.js
@@ -93,11 +93,6 @@ class RubyApplication extends CompilableComponent {
       {atNewLine: true});
     }
     const args = ['install', '--binstubs', '--without'].concat(options.exclude);
-    // Nokogiri requires to use the system libraries
-    if (nfile.contains(nfile.join(this.prefix, 'Gemfile'), 'nokogiri')) {
-      this.sandbox.runProgram(nfile.join(this.be.prefixDir, 'ruby/bin/bundle'),
-                                         ['config', 'build.nokogiri', '--use-system-libraries'], {cwd: this.prefix});
-    }
     this.sandbox.runProgram(nfile.join(this.be.prefixDir, 'ruby/bin/bundle'),
                                          args.concat('--no-deployment'), {cwd: this.prefix});
     this.sandbox.runProgram(nfile.join(this.be.prefixDir, 'ruby/bin/bundle'),

--- a/test/ruby-application.js
+++ b/test/ruby-application.js
@@ -72,7 +72,6 @@ describe('Ruby Application', function() {
       'Passenger core online'
     );
     rubyApplication.install();
-    expect(log.text).to.contain('"config" "build.nokogiri" "--use-system-libraries"'); // Configure nokogiri if present
     expect(log.text).to.contain('"install" "--binstubs" "--without" "development" "sqlite" "test" "--no-deployment"');
     expect(log.text).to.contain('"install" "--binstubs" "--without" "development" "sqlite" "test" "--deployment"');
     expect(log.text).to.contain('"exec" "passenger" "start"');


### PR DESCRIPTION
Nokogiri doesn't require anymore to use System libraries.