### PR TITLE
Fix goBuildDependencies installation

### DIFF
--- a/go-project/index.js
+++ b/go-project/index.js
@@ -37,7 +37,7 @@ class GoProject extends MakeComponent {
 
   get buildDependencies() {
     const goTar = `go${this.goVersion}.linux-amd64.tar.gz`;
-    const goGetCommands = this.goBuildDependencies.map((dep) => `go get ${dep}`);
+    const goGetCommands = this.goBuildDependencies.map((dep) => `/usr/local/go/bin/go get ${dep}`);
     return [
       {
         type: 'go',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
The Dockerfile does not set the environment variables, so `PATH` does not include the Go installation directory during build time.