### PR TITLE
Add default GOPATH to the PATH

### DIFF
--- a/go-project/index.js
+++ b/go-project/index.js
@@ -19,7 +19,7 @@ class GoProject extends MakeComponent {
 
   getExportableEnvironmentVariables() {
     return Object.assign(super.getExportableEnvironmentVariables(), {
-      PATH: `${process.env.PATH}:${this.goPath}/bin:/usr/local/go/bin`,
+      PATH: `${process.env.PATH}:${this.goPath}/bin:${process.env.HOME}/go/bin:/usr/local/go/bin`,
       GOPATH: this.goPath,
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
This allows using the binaries installed using `go get` with the default `GOPATH` (`goBuildDependencies`).