### PR TITLE
GoProject: remove environment variables inherited from CompilableComponents

### DIFF
--- a/go-project/index.js
+++ b/go-project/index.js
@@ -18,10 +18,10 @@ class GoProject extends MakeComponent {
   }
 
   getExportableEnvironmentVariables() {
-    return Object.assign(super.getExportableEnvironmentVariables(), {
+    return {
       PATH: `${process.env.PATH}:${this.goPath}/bin:${process.env.HOME}/go/bin:/usr/local/go/bin`,
       GOPATH: this.goPath,
-    });
+    };
   }
 
   get goVersion() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
These causes issues when building some go projects, and keeping them has no benefit.