### PR TITLE
Add bundler 1.x for Ruby 2.5 and update version, add Ruby 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {

--- a/ruby-application/ruby25.js
+++ b/ruby-application/ruby25.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const RubyApplication = require('./index');
+const nfile = require('nami-utils').file;
 
 /**
  * Class representing a ruby Application for versions 2.5.X

--- a/ruby-application/ruby25.js
+++ b/ruby-application/ruby25.js
@@ -9,7 +9,12 @@ const RubyApplication = require('./index');
  * @extends rubyApplication
  */
 class Ruby25Application extends RubyApplication {
-  rubyVersion() { return '2.5.1-0'; }
+  rubyVersion() { return '2.5.3-0'; }
+  install(options) {
+    // Install latest Bundler 1.x gem, which is still used by some Ruby 2.5 applications
+    this.sandbox.runProgram(nfile.join(this.be.prefixDir, 'ruby/bin/gem'), ['install', 'bundler', '-v', '< 2']);
+    super.install(options);
+  }
 }
 
 module.exports = Ruby25Application;

--- a/ruby-application/ruby26.js
+++ b/ruby-application/ruby26.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const RubyApplication = require('./index');
+
+/**
+ * Class representing a ruby Application for versions 2.6.X
+ * @namespace BaseComponents.Ruby26Application
+ * @class
+ * @extends rubyApplication
+ */
+class Ruby26Application extends RubyApplication {
+  rubyVersion() { return '2.6.1-0'; }
+}
+
+module.exports = Ruby26Application;


### PR DESCRIPTION
This adds bundler 1.x for Ruby 2.5, which is required for some Ruby 2.5 applications (e.g. Discourse).

We also update the Ruby 2.5 version and add a new class for Ruby 2.6 applications.