### PR TITLE
Add 'WordPressPlugin' component

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ const commonTasks = require('bitnami-gulp-common-tasks')(gulp);
 
 const testFiles = './test/*.js';
 const srcFiles = [
-  index.js',
+  'index.js',
   'go-project/*.js',
   'nginx-module/*.js',
   'node-application/*.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,17 @@ const commonTasks = require('bitnami-gulp-common-tasks')(gulp);
 /* CI tasks */
 
 const testFiles = './test/*.js';
-const srcFiles = ['index.js', 'ruby-application/*.js', 'node-application/*.js', 'php-application/*.js', testFiles];
+const srcFiles = [
+  index.js',
+  'go-project/*.js',
+  'nginx-module/*.js',
+  'node-application/*.js',
+  'pecl-component/*.js',
+  'php-application/*.js',
+  'ruby-application/*.js',
+  'wordpress-plugin/*.js',
+  testFiles,
+];
 const testArgs = {sources: srcFiles, tests: testFiles};
 
 commonTasks.test(testArgs);

--- a/index.js
+++ b/index.js
@@ -20,4 +20,5 @@ module.exports = {
   PHP73Application: require('./php-application/php73'),
   PeclComponent: require('./pecl-component'),
   GoProject: require('./go-project'),
+  WordPressPlugin: require('./wordpress-plugin'),
 };

--- a/nginx-module/index.js
+++ b/nginx-module/index.js
@@ -26,7 +26,7 @@ class NginxModule extends CompiledComponent {
 
   nginxAdditionalConfigureFlags() {
     if (this.isDynamicModule) {
-     return [`--add-dynamic-module=${this.srcDir}`];
+      return [`--add-dynamic-module=${this.srcDir}`];
     }
     return [`--add-module=${this.srcDir}`];
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {

--- a/test/wordpress-plugin.js
+++ b/test/wordpress-plugin.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const WordPressPlugin = require('../wordpress-plugin');
+
+const helpers = require('blacksmith/test/helpers');
+const chai = require('chai');
+const chaiFs = require('chai-fs');
+const expect = chai.expect;
+chai.use(chaiFs);
+
+describe('WordPress Plugin', function() {
+  let be;
+  let test;
+
+  function createWordPressPlugin() {
+    const component = helpers.createComponent(test);
+    const wordpressPlugin = new WordPressPlugin({
+      version: component.version,
+      id: component.id,
+      licenses: [{
+        type: component.licenseType,
+        licenseRelativePath: component.licenseRelativePath,
+        main: true
+      }]
+    });
+    wordpressPlugin.setup({be});
+    return wordpressPlugin;
+  }
+
+  beforeEach('prepare environment', () => {
+    helpers.cleanTestEnv();
+    test = helpers.createTestEnv();
+    be = helpers.getDummyBuildEnvironment(test);
+  });
+
+  afterEach('clean environment', () => {
+    helpers.cleanTestEnv();
+  });
+
+  it('should return \'wordpress/wp-content/plugins\' as prefix by default', () => {
+    const wordpressPlugin = createWordPressPlugin();
+    const wordpressPluginPrefix = wordpressPlugin.prefix();
+    expect(wordpressPluginPrefix).to.match(/wordpress\/wp-content\/plugins/);
+  });
+});

--- a/test/wordpress-plugin.js
+++ b/test/wordpress-plugin.js
@@ -39,7 +39,7 @@ describe('WordPress Plugin', function() {
 
   it('should return \'wordpress/wp-content/plugins\' as prefix by default', () => {
     const wordpressPlugin = createWordPressPlugin();
-    const wordpressPluginPrefix = wordpressPlugin.prefix();
+    const wordpressPluginPrefix = wordpressPlugin.prefix;
     expect(wordpressPluginPrefix).to.match(/wordpress\/wp-content\/plugins/);
   });
 });

--- a/wordpress-plugin/index.js
+++ b/wordpress-plugin/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const nfile = require('nami-utils').file;
+const CompiledComponent = require('blacksmith/lib/base-components').CompiledComponent;
+
+class WordPressPlugin extends CompiledComponent {
+  /**
+   * Get build prefix
+   * @returns {mixed}
+  */
+  get prefix() {
+    return nfile.join(this.be.prefixDir, 'wordpress', 'wp-content', 'plugins');
+  }
+}
+
+module.exports = WordPressPlugin;

--- a/wordpress-plugin/index.js
+++ b/wordpress-plugin/index.js
@@ -1,16 +1,30 @@
 'use strict';
 
 const nfile = require('nami-utils').file;
+const path = require('path');
+const _ = require('nami-utils/lodash-extra');
+const tarballUtils = require('tarball-utils');
 const CompiledComponent = require('blacksmith/lib/base-components').CompiledComponent;
 
 class WordPressPlugin extends CompiledComponent {
   /**
    * Get build prefix
-   * @returns {mixed}
   */
   get prefix() {
-    const pluginDirname = this.id.replace(/wordpress-plugin-/g,'');
-    return nfile.join(this.be.prefixDir, 'wordpress', 'wp-content', 'plugins', pluginDirname);
+    return nfile.join(this.be.prefixDir, 'wordpress', 'wp-content', 'plugins');
+  }
+  /**
+  * Extract component tarball in srcDir
+  */
+  extract() {
+    if (_.isEmpty(this.source.tarball)) {
+      throw new Error(`The source tarball is missing. Received ${this.source.tarball}`);
+    }
+    if (!path.isAbsolute(this.source.tarball)) {
+      throw new Error(`Path to source tarball should be absolute. Found ${this.source.tarball}`);
+    }
+    this._validateChecksum(this.source.tarball, this.source.sha256);
+    tarballUtils.unpack(this.source.tarball, this.srcDir);
   }
 }
 

--- a/wordpress-plugin/index.js
+++ b/wordpress-plugin/index.js
@@ -9,7 +9,8 @@ class WordPressPlugin extends CompiledComponent {
    * @returns {mixed}
   */
   get prefix() {
-    return nfile.join(this.be.prefixDir, 'wordpress', 'wp-content', 'plugins');
+    const pluginDirname = this.id.replace(/wordpress-plugin-/g,'');
+    return nfile.join(this.be.prefixDir, 'wordpress', 'wp-content', 'plugins', pluginDirname);
   }
 }
 

--- a/wordpress-plugin/index.js
+++ b/wordpress-plugin/index.js
@@ -26,6 +26,10 @@ class WordPressPlugin extends CompiledComponent {
     this._validateChecksum(this.source.tarball, this.source.sha256);
     tarballUtils.unpack(this.source.tarball, this.srcDir);
   }
+  /**
+   * Each plugin includes its own license in the source tarball
+   */
+  fulfillLicenseRequirements() {}
 }
 
 module.exports = WordPressPlugin;


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

### Summary

This PR adds a new component **'WordPressPlugin'** to be used to create a component per plugin so we can included them on WordPress recipe.