### PR TITLE
Fix bug installing Go deps when multiple Go components are added to a recipe

### DIFF
--- a/go-project/index.js
+++ b/go-project/index.js
@@ -38,7 +38,7 @@ class GoProject extends MakeComponent {
   get buildDependencies() {
     const goTar = `go${this.goVersion}.linux-amd64.tar.gz`;
     const goGetCommands = this.goBuildDependencies.map((dep) => `/usr/local/go/bin/go get ${dep}`);
-    return [
+    const buildDependencies = [
       {
         type: 'go',
         id: 'go',
@@ -48,6 +48,14 @@ class GoProject extends MakeComponent {
         ].concat(goGetCommands),
       }
     ];
+    this.goBuildDependencies.forEach((dep) => {
+      buildDependencies.push({
+        type: 'go',
+        id: `go-builddependency-${nfile.basename(dep)}`,
+        installCommands: [`/usr/local/go/bin/go get ${dep}`],
+      });
+    });
+    return buildDependencies;
   }
 
   configure() {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
If multiple Go components are added to a recipe, there is a conflict due to the "go" identifier being present twice. Therefore, only the dependencies for the first Go component in the recipe is respected, and the rest are ignored.

With this PR, any Go dependency is respected.