### PR TITLE
Remove fulfillLicenseRequirements for WordPress plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {

--- a/wordpress-plugin/index.js
+++ b/wordpress-plugin/index.js
@@ -26,10 +26,6 @@ class WordPressPlugin extends CompiledComponent {
     this._validateChecksum(this.source.tarball, this.source.sha256);
     tarballUtils.unpack(this.source.tarball, this.srcDir);
   }
-  /**
-   * Each plugin includes its own license in the source tarball
-   */
-  fulfillLicenseRequirements() {}
 }
 
 module.exports = WordPressPlugin;


### PR DESCRIPTION
This method is not needed anymore. 