### PR TITLE
Fix path to license files for WordPress plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {

--- a/test/wordpress-plugin.js
+++ b/test/wordpress-plugin.js
@@ -37,9 +37,9 @@ describe('WordPress Plugin', function() {
     helpers.cleanTestEnv();
   });
 
-  it('should return \'wordpress/wp-content/plugins\' as prefix by default', () => {
+  it('should return \'wordpress\' as prefix by default', () => {
     const wordpressPlugin = createWordPressPlugin();
     const wordpressPluginPrefix = wordpressPlugin.prefix;
-    expect(wordpressPluginPrefix).to.match(/wordpress\/wp-content\/plugins/);
+    expect(wordpressPluginPrefix).to.match(/wordpress$/);
   });
 });

--- a/wordpress-plugin/index.js
+++ b/wordpress-plugin/index.js
@@ -32,7 +32,7 @@ class WordPressPlugin extends CompiledComponent {
   install() {
     const pluginDest = nfile.join(this.prefix, 'wp-content', 'plugins');
     nfile.mkdir(pluginDest);
-    nfile.copy(nfile.join(this.srcDir, '*'), this.pluginDest);
+    nfile.copy(nfile.join(this.srcDir, '*'), pluginDest);
   }
 }
 

--- a/wordpress-plugin/index.js
+++ b/wordpress-plugin/index.js
@@ -9,13 +9,13 @@ const CompiledComponent = require('blacksmith/lib/base-components').CompiledComp
 class WordPressPlugin extends CompiledComponent {
   /**
    * Get build prefix
-  */
+   */
   get prefix() {
-    return nfile.join(this.be.prefixDir, 'wordpress', 'wp-content', 'plugins');
+    return nfile.join(this.be.prefixDir, 'wordpress');
   }
   /**
-  * Extract component tarball in srcDir
-  */
+   * Extract component tarball in srcDir
+   */
   extract() {
     if (_.isEmpty(this.source.tarball)) {
       throw new Error(`The source tarball is missing. Received ${this.source.tarball}`);
@@ -25,6 +25,14 @@ class WordPressPlugin extends CompiledComponent {
     }
     this._validateChecksum(this.source.tarball, this.source.sha256);
     tarballUtils.unpack(this.source.tarball, this.srcDir);
+  }
+  /**
+   * Install to final location
+   */
+  install() {
+    const pluginDest = nfile.join(this.prefix, 'wp-content', 'plugins');
+    nfile.mkdir(pluginDest);
+    nfile.copy(nfile.join(this.srcDir, '*'), this.pluginDest);
   }
 }
 


### PR DESCRIPTION
Currently they are being put in `/opt/bitnami/wordpress/wp-content/plugins/licenses`, but they should be located in `/opt/bitnami/wordpress/licenses`.