### PR TITLE
Obtain ruby dependencies in srcDir

### DIFF
--- a/ruby-application/index.js
+++ b/ruby-application/index.js
@@ -98,7 +98,7 @@ class RubyApplication extends CompilableComponent {
     if (options.installPassenger) {
       // Passenger first boot to download agent and Nginx
       this.sandbox.runProgram(nfile.join(this.be.prefixDir, 'ruby/bin/bundle'), ['exec', 'passenger', 'start'], {
-        env: {PATH: `${process.env.PATH}:${nfile.join(this.srcDir, 'ruby/bin')}`},
+        env: {PATH: `${process.env.PATH}:${nfile.join(this.be.prefixDir, 'ruby/bin')}`},
         runInBackground: true, cwd: this.srcDir});
       const logFile = nfile.join(this.srcDir, 'log/passenger.3000.log');
       let started = false;

--- a/test/ruby-application.js
+++ b/test/ruby-application.js
@@ -63,6 +63,7 @@ describe('Ruby Application', function() {
     rubyApplication.patch();
     rubyApplication.postExtract();
     rubyApplication.build();
+    rubyApplication.install();
     expect(path.join(path.join(test.prefix, component.id, 'Gemfile'))).to.be.a.file();
     expect(path.join(path.join(test.prefix, component.id, 'config/database.yml.example'))).to.not.be.a.path();
     expect(path.join(path.join(test.prefix, component.id, 'config/database.yml'))).to.be.a.file();
@@ -72,7 +73,6 @@ describe('Ruby Application', function() {
       path.join(test.prefix, component.id, 'log/passenger.3000.log'), // Simulate passenger log
       'Passenger core online'
     );
-    rubyApplication.install();
     expect(log.text).to.contain('"install" "--binstubs" "--without" "development" "sqlite" "test" "--no-deployment"');
     expect(log.text).to.contain('"install" "--binstubs" "--without" "development" "sqlite" "test" "--deployment"');
     expect(log.text).to.contain('"exec" "passenger" "start"');

--- a/test/ruby-application.js
+++ b/test/ruby-application.js
@@ -63,16 +63,16 @@ describe('Ruby Application', function() {
     rubyApplication.patch();
     rubyApplication.postExtract();
     rubyApplication.build();
+    rubyApplication.postBuild();
+    fs.mkdirSync(path.join(test.sandbox, `${component.id}-${component.version}/log`));
+    fs.writeFileSync(
+      path.join(test.sandbox, `${component.id}-${component.version}/log/passenger.3000.log`), // Simulate passenger log
+      'Passenger core online'
+    );
     rubyApplication.install();
     expect(path.join(path.join(test.prefix, component.id, 'Gemfile'))).to.be.a.file();
     expect(path.join(path.join(test.prefix, component.id, 'config/database.yml.example'))).to.not.be.a.path();
     expect(path.join(path.join(test.prefix, component.id, 'config/database.yml'))).to.be.a.file();
-    rubyApplication.postBuild();
-    fs.mkdirSync(path.join(test.prefix, component.id, 'log'));
-    fs.writeFileSync(
-      path.join(test.prefix, component.id, 'log/passenger.3000.log'), // Simulate passenger log
-      'Passenger core online'
-    );
     expect(log.text).to.contain('"install" "--binstubs" "--without" "development" "sqlite" "test" "--no-deployment"');
     expect(log.text).to.contain('"install" "--binstubs" "--without" "development" "sqlite" "test" "--deployment"');
     expect(log.text).to.contain('"exec" "passenger" "start"');


### PR DESCRIPTION
This change download the required gems in srcDir before copying all the content to prefixDir