### PR TITLE
Add libwebp package as a dependency of PHP applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith-extra-component-types",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "description": "Additional blacksmith component types",
   "main": "index.js",
   "dependencies": {

--- a/php-application/index.js
+++ b/php-application/index.js
@@ -73,6 +73,7 @@ class PHPApplication extends CompiledComponent {
         'libtasn1-6',
         'libtidy-dev',
         'libtinfo5',
+        'libwebp-dev',
         'libxml2',
         'libxslt1.1',
         'libzip-dev',
@@ -113,6 +114,7 @@ class PHPApplication extends CompiledComponent {
         'libssh2',
         'libstdc++',
         // 'libtidy-devel', TODO: add EPEL
+        'libwebp-devel',
         'libxml2',
         'libxslt',
         'ncurses-libs',


### PR DESCRIPTION
The new PHP version in use includes the `libwebp` tool, which depends on the system libraries.

Signed-off-by: Gonzalo Gomez Gracia <gonzalog@vmware.com>